### PR TITLE
ci: enable manual /re-review trigger for claude-code-review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,6 +6,14 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, review_requested, synchronize]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to re-review"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -20,3 +28,4 @@ jobs:
     with:
       project_type: generic
       block_on_critical: true
+      pr_number: ${{ inputs.pr_number }}


### PR DESCRIPTION
Add issue_comment + workflow_dispatch triggers and a pr_number passthrough to the thin caller so the centrally-maintained review engine (@v1) can be re-triggered via a /re-review PR comment or workflow_dispatch.
